### PR TITLE
Disable colors when invoking GIT or else the script fails.

### DIFF
--- a/git-loc
+++ b/git-loc
@@ -39,7 +39,7 @@ prevfolder = os.getcwd()
 if extfolder:
     os.chdir(targetfolder)
 
-for x in popen('git log --reverse -p'):
+for x in popen('git log --no-color --reverse -p'):
 	if x.startswith('commit'):
 		pop()
 		hsh=x[7:14];


### PR DESCRIPTION
Prevents a traceback NameError: global name 'hsh' is not defined when using
[color]
    ui = always
in .gitconfig
